### PR TITLE
Fix #5: rename local variable to follow naming convention

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeDetailsView.java
+++ b/jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeDetailsView.java
@@ -31,11 +31,11 @@ public sealed abstract class DatabaseChangeDetailsView extends AnchorPane permit
     /// @see AnchorPane#getChildren()
     /// @see javafx.collections.ObservableList#setAll(Object[])
     protected void setAllAnchorsAndAttachChild(Node child) {
-        double ANCHOR_PANE_OFFSET = 8D;
-        setLeftAnchor(child, ANCHOR_PANE_OFFSET);
-        setTopAnchor(child, ANCHOR_PANE_OFFSET);
-        setRightAnchor(child, ANCHOR_PANE_OFFSET);
-        setBottomAnchor(child, ANCHOR_PANE_OFFSET);
+        double anchorPaneOffset = 8D;
+        setLeftAnchor(child, anchorPaneOffset);
+        setTopAnchor(child, anchorPaneOffset);
+        setRightAnchor(child, anchorPaneOffset);
+        setBottomAnchor(child, anchorPaneOffset);
         this.getChildren().setAll(child);
     }
 }


### PR DESCRIPTION
### Related issues and pull requests

Closes #5 

### PR Description

This PR fixes a SonarQube-reported maintainability issue by renaming a local variable in DatabaseChangeDetailsView.java to follow the required Java naming convention.


### Steps to test

   1. Open the File: jabgui/src/main/java/org/jabref/gui/collab/DatabaseChangeDetailsView.java 
   2.  You can view that Variable (old) "ANCHOR_PANE_OFFSET" is renamed to (new) "anchorPaneOffset"
   

### Checklist

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [x] I manually tested my changes in running JabRef (always required)
- [ ] I added JUnit tests for changes (if applicable)
- [ ] I added screenshots in the PR description (if change is visible to the user)
- [ ] I added a screenshot in the PR description showing a library with a single entry with me as author and as title the issue number
- [ ] I described the change in `CHANGELOG.md` in a way that can be understood by the average user (if change is visible to the user)
- [ ] I checked the [user documentation](https://docs.jabref.org/) for up to dateness and submitted a pull request to our [user documentation repository](https://github.com/JabRef/user-documentation/tree/main/en)